### PR TITLE
replace selectorSlotsLength with struct SelectorSlot

### DIFF
--- a/contracts/DiamondFacet.sol
+++ b/contracts/DiamondFacet.sol
@@ -19,7 +19,7 @@ contract DiamondFacet is IDiamond, DiamondStorageContract {
     // This struct is used to prevent getting the error "CompilerError: Stack too deep, try removing local variables."
     // See this article: https://medium.com/1milliondevs/compilererror-stack-too-deep-try-removing-local-variables-solved-a6bcecc16231
     struct SlotInfo {
-        uint originalSelectorSlotsLength;
+        //uint originalSelectorSlotsLength;
         bytes32 selectorSlot;
         uint oldSelectorSlotsIndex;
         uint oldSelectorSlotIndex;
@@ -31,9 +31,11 @@ contract DiamondFacet is IDiamond, DiamondStorageContract {
         DiamondStorage storage ds = diamondStorage();
         require(msg.sender == ds.contractOwner, "Must own the contract.");
         SlotInfo memory slot;
-        slot.originalSelectorSlotsLength = ds.selectorSlotsLength;
-        uint selectorSlotsLength = uint128(slot.originalSelectorSlotsLength);
-        uint selectorSlotLength = uint128(slot.originalSelectorSlotsLength >> 128);
+        //slot.originalSelectorSlotsLength = ds.selectorSlotsLength;
+        //uint selectorSlotsLength = uint128(slot.originalSelectorSlotsLength);
+        uint selectorSlotsLength = ds.selectorSlot.slotsLength;
+        //uint selectorSlotLength = uint128(slot.originalSelectorSlotsLength >> 128);
+        uint selectorSlotLength = ds.selectorSlot.lastSlotLength;
         if(selectorSlotLength > 0) {
             slot.selectorSlot = ds.selectorSlots[selectorSlotsLength];
         }
@@ -121,9 +123,14 @@ contract DiamondFacet is IDiamond, DiamondStorageContract {
                 }
             }
         }
-        uint newSelectorSlotsLength = selectorSlotLength << 128 | selectorSlotsLength;
-        if(newSelectorSlotsLength != slot.originalSelectorSlotsLength) {
-            ds.selectorSlotsLength = newSelectorSlotsLength;
+        //uint newSelectorSlotsLength = selectorSlotLength << 128 | selectorSlotsLength;
+        //if(newSelectorSlotsLength != slot.originalSelectorSlotsLength) {
+        if (selectorSlotsLength != ds.selectorSlot.slotsLength || selectorSlotLength != ds.selectorSlot.lastSlotLength) {
+            //ds.selectorSlotsLength = newSelectorSlotsLength;
+            ds.selectorSlot = SelectorSlot({
+                slotsLength: uint64(selectorSlotsLength),
+                lastSlotLength: uint8(selectorSlotLength)
+            });
         }
         if(slot.newSlot) {
             ds.selectorSlots[selectorSlotsLength] = slot.selectorSlot;

--- a/contracts/DiamondLoupeFacet.sol
+++ b/contracts/DiamondLoupeFacet.sol
@@ -37,19 +37,22 @@ contract DiamondLoupeFacet is IDiamondLoupe, DiamondStorageContract {
     /// sel1, sel2, sel3 etc. are four-byte function selectors.
     function facets() external view override returns(bytes[] memory) {
         DiamondStorage storage ds = diamondStorage();
-        uint totalSelectorSlots = ds.selectorSlotsLength;
-        uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
-        totalSelectorSlots = uint128(totalSelectorSlots);        
-        uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
-        if(selectorSlotLength > 0) {
-            totalSelectorSlots++;
-        }
+        //uint totalSelectorSlots = ds.selectorSlotsLength;
+        //uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
+        //totalSelectorSlots = uint128(totalSelectorSlots);        
+        //uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
+        //if(selectorSlotLength > 0) {
+        //if(ds.selectorSlot.lastSlotLength > 0) {
+        //    totalSelectorSlots++;
+        //}
+        uint totalSelectors = ds.selectorSlot.slotsLength * 8 + ds.selectorSlot.lastSlotLength;
+        uint defaultSize = totalSelectors > 20 ? 20 : totalSelectors;
         
         // get default size of arrays
-        uint defaultSize = totalSelectors;        
-        if(defaultSize > 20) {
-            defaultSize = 20;
-        }        
+        //uint defaultSize = totalSelectors;        
+        //if(defaultSize > 20) {
+        //    defaultSize = 20;
+        //}        
         Facet[] memory facets_ = new Facet[](defaultSize);
         uint8[] memory numFacetSelectors = new uint8[](defaultSize);
         uint numFacets;
@@ -132,13 +135,14 @@ contract DiamondLoupeFacet is IDiamondLoupe, DiamondStorageContract {
     /// return abi.encodePacked(selector1, selector2, selector3, ...)
     function facetFunctionSelectors(address _facet) external view override returns(bytes memory) {
         DiamondStorage storage ds = diamondStorage();
-        uint totalSelectorSlots = ds.selectorSlotsLength;
-        uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
-        totalSelectorSlots = uint128(totalSelectorSlots);        
-        uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
-        if(selectorSlotLength > 0) {
-            totalSelectorSlots++;
-        }                       
+        //uint totalSelectorSlots = ds.selectorSlotsLength;
+        //uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
+        //totalSelectorSlots = uint128(totalSelectorSlots);        
+        //uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
+        //if(selectorSlotLength > 0) {
+        //    totalSelectorSlots++;
+        //}                       
+        uint totalSelectors = ds.selectorSlot.slotsLength * 8 + ds.selectorSlot.lastSlotLength;
 
         uint numFacetSelectors;        
         bytes4[] memory facetSelectors = new bytes4[](totalSelectors);
@@ -176,13 +180,15 @@ contract DiamondLoupeFacet is IDiamondLoupe, DiamondStorageContract {
     /// return abi.encodePacked(facet1, facet2, facet3, ...)
     function facetAddresses() external view override returns(bytes memory) {
         DiamondStorage storage ds = diamondStorage();
-        uint totalSelectorSlots = ds.selectorSlotsLength;
-        uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
-        totalSelectorSlots = uint128(totalSelectorSlots);        
-        uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
-        if(selectorSlotLength > 0) {
-            totalSelectorSlots++;
-        }        
+        //uint totalSelectorSlots = ds.selectorSlotsLength;
+        //uint selectorSlotLength = uint128(totalSelectorSlots >> 128);
+        //totalSelectorSlots = uint128(totalSelectorSlots);        
+        //uint totalSelectors = totalSelectorSlots * 8 + selectorSlotLength;
+        //if(selectorSlotLength > 0) {
+        //    totalSelectorSlots++;
+        //}        
+        uint totalSelectors = ds.selectorSlot.slotsLength * 8 + ds.selectorSlot.lastSlotLength;
+
         address[] memory facets_ = new address[](totalSelectors);
         uint numFacets;
         uint selectorCount;

--- a/contracts/DiamondStorageContract.sol
+++ b/contracts/DiamondStorageContract.sol
@@ -5,10 +5,19 @@ contract DiamondStorageContract {
 
     bytes32 constant DIAMOND_STORAGE_POSITION = keccak256("diamond.standard.diamond.storage");
 
+    // slotsLength is the number of 32-byte slots in selectorSlot.
+    // lastSlotLength is the number of selectors in the last slot of selectorSlot.
+    struct SelectorSlot {
+        uint64 slotsLength; // 8-byte
+        uint8 lastSlotLength; // 1-byte
+    } // total 9-byte
+
     struct DiamondStorage {
         
         // owner of the contract
         address contractOwner;
+
+        SelectorSlot selectorSlot; // to pack with the address above within one 256-bit
 
         // maps function selectors to the facets that execute the functions.
         // and maps the selectors to the slot in the selectorSlots array.
@@ -24,7 +33,7 @@ contract DiamondStorageContract {
         // selectorSlotsLength is the number of 32-byte slots in selectorSlots.
         // selectorSlotLength is the number of selectors in the last slot of
         // selectorSlots.
-        uint selectorSlotsLength;
+        //uint selectorSlotsLength;
 
         // Used to query if a contract implements an interface.
         // Used to implement ERC-165.


### PR DESCRIPTION
Hi Nick,

I think your Diamond standard is great and deserves much more attention.

I also think its popularity is hurt by its hard-to-understand concept and implementation.

In this PR, I replace selectorSlotsLength (and its bit operations) with struct SelectorSlot. The goal is to make the reference implementation easier to follow.

All tests pass. Though some tests incur slightly more, up to 1.7% more, gas. I believe it's a worthy price to pay for the wider adoption of the Diamond standard. After all, diamondCut is not a frequent operation.

Thank you for your consideration.

Jerry

P.S., feel free to ping me (jerryji) in Discord.

